### PR TITLE
chore: add dependabot grouping for WBT, update refs to v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,5 @@ updates:
     groups:
       wow-build-tools:
         patterns:
-          - "McTalian/wow-build-tools*"
-          - "McTalian-WoW-Addons/wow-build-tools*"
+          - McTalian/wow-build-tools*
+          - McTalian-WoW-Addons/wow-build-tools*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      wow-build-tools:
+        patterns:
+          - "McTalian/wow-build-tools*"
+          - "McTalian-WoW-Addons/wow-build-tools*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       actions: write
       pull-requests: write
       issues: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/ci.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/ci.yml@v1
     with:
       addon-name: TokenTransmogTooltips
       rockspec-name: tokentransmogtooltips-1-1.rockspec

--- a/.github/workflows/package-and-distribute-adhoc-curseforge.yml
+++ b/.github/workflows/package-and-distribute-adhoc-curseforge.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Package and distribute
         env:
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
-        uses: McTalian-WoW-Addons/wow-build-tools@v1-beta
+        uses: McTalian-WoW-Addons/wow-build-tools@v1
         with:
           args: -t ./TokenTransmogTooltips -r ./.release

--- a/.github/workflows/package-and-distribute-adhoc-wago.yml
+++ b/.github/workflows/package-and-distribute-adhoc-wago.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Package and distribute
         env:
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
-        uses: McTalian-WoW-Addons/wow-build-tools@v1-beta
+        uses: McTalian-WoW-Addons/wow-build-tools@v1
         with:
           args: -t ./TokenTransmogTooltips -r ./.release

--- a/.github/workflows/package-and-distribute-adhoc-wowi.yml
+++ b/.github/workflows/package-and-distribute-adhoc-wowi.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Package and distribute
         env:
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
-        uses: McTalian-WoW-Addons/wow-build-tools@v1-beta
+        uses: McTalian-WoW-Addons/wow-build-tools@v1
         with:
           args: -t ./TokenTransmogTooltips -r ./.release

--- a/.github/workflows/package-and-distribute.yml
+++ b/.github/workflows/package-and-distribute.yml
@@ -11,7 +11,7 @@ jobs:
   package-and-release:
     permissions:
       contents: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/package-and-distribute.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/package-and-distribute.yml@v1
     with:
       addon-name: TokenTransmogTooltips
       avatar-url: https://raw.githubusercontent.com/McTalian-WoW-Addons/TokenTransmogTooltips/refs/heads/main/logo.png

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,7 +17,7 @@ jobs:
       actions: write
       pull-requests: write
       checks: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/pr-checks.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/pr-checks.yml@v1
     with:
       addon-name: TokenTransmogTooltips
       rockspec-name: tokentransmogtooltips-1-1.rockspec

--- a/.github/workflows/toc-updater.yml
+++ b/.github/workflows/toc-updater.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/toc-updater.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/toc-updater.yml@v1
     with:
       addon-name: TokenTransmogTooltips
       pr-body: |


### PR DESCRIPTION
- Groups all `McTalian/wow-build-tools*` and `McTalian-WoW-Addons/wow-build-tools*` dependencies into a single Dependabot PR (instead of one per reusable workflow)
- Updates `@v1-beta` → `@v1` across all workflow files